### PR TITLE
Recreate models on startup

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -9,6 +9,7 @@ var cors = require('cors');
 const bodyParser = require('body-parser');
 const { errorHandler } = require('./utils');
 const { requireAuthentication } = require('./middleware/authentication');
+const { initModels } = require('./utils/init-models');
 const app = express();
 
 app.use(express.static(path.join(__dirname, '../frontend/build')));
@@ -26,13 +27,15 @@ mongoose.connect(process.env.DB_URI, {
 });
 
 mongoose.connection
-    .once('open', () => console.log('Connected to the database!'))
+    .once('open', () => {
+        console.log('Connected to the DB');
+        initModels();
+    })
     .on('error', (error) =>
         console.log('Error connecting to the database: ', error),
     );
 
 mongoose.set('useFindAndModify', false);
-
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 

--- a/backend/routes/api/metadata.js
+++ b/backend/routes/api/metadata.js
@@ -6,7 +6,7 @@ const { models, fileSchema, stepStatusEnum } = require('../../models');
 const { fieldEnum } = require('../../models/Metadata');
 const mongoose = require('mongoose');
 
-const addCollection = (stepMetadata) => {
+const generateSchemaFromMetadata = (stepMetadata) => {
     let stepSchema = {};
     stepSchema.patientId = { type: String, required: true, unique: true };
     stepSchema.status = {
@@ -223,3 +223,4 @@ router.delete(
 );
 
 module.exports = router;
+module.exports.generateSchemaFromMetadata = generateSchemaFromMetadata;

--- a/backend/utils/init-models.js
+++ b/backend/utils/init-models.js
@@ -1,0 +1,11 @@
+const { models } = require('../models');
+const { generateSchemaFromMetadata } = require('../routes/api/metadata');
+
+const initModels = async () => {
+    const steps = await models.Step.find();
+    steps.forEach((step) => {
+        generateSchemaFromMetadata(step);
+    });
+};
+
+module.exports = { initModels };


### PR DESCRIPTION
Every time the backend starts up we create all models. This will make them accessible by model name.
Closes #165 