### PR TITLE
format last edited

### DIFF
--- a/frontend/src/components/Table/MainTable.js
+++ b/frontend/src/components/Table/MainTable.js
@@ -25,6 +25,7 @@ import {
     TableHeaderType,
 } from '../../utils/custom-proptypes';
 import { PATIENT_STATUS } from '../../utils/constants';
+import { formatDate } from '../../utils/date';
 
 const StyledTableCell = withStyles((theme) => ({
     head: {
@@ -100,6 +101,14 @@ const MainTable = ({ languageData, patients, headers, rowIds }) => {
                 {lang.components.bottombar.feedback}
             </div>
         ),
+    };
+
+    const getPatientField = (patient, fieldKey) => {
+        const rawData = resolveObjPath(patient, fieldKey);
+        if (fieldKey === 'lastEdited')
+            return formatDate(new Date(rawData), key);
+
+        return rawData;
     };
 
     return (
@@ -185,7 +194,7 @@ const MainTable = ({ languageData, patients, headers, rowIds }) => {
                                                 )}
                                             </>
                                         ) : (
-                                            resolveObjPath(patient, id)
+                                            getPatientField(patient, id)
                                         )}
                                     </StyledTableCell>
                                 ))}


### PR DESCRIPTION
Format the dates on the home screen to be readable (instead of a UTM timezone)

![image](https://user-images.githubusercontent.com/24998201/124804634-235a4c80-df20-11eb-9f75-75dd75580eb4.png)

Closes #240 