### PR TITLE
Photo performance

### DIFF
--- a/frontend/src/components/Fields/PhotoField.js
+++ b/frontend/src/components/Fields/PhotoField.js
@@ -10,11 +10,10 @@ import { useTranslations } from '../../hooks/useTranslations';
 import { NUMBER_OF_PHOTOS_FOR_BULLET_VIEW } from '../../utils/constants';
 import {
     convertPhotosToURI,
-    dataURItoBlob
+    dataURItoBlob,
 } from '../../utils/photoManipulation';
 import { StyledButton } from '../StyledButton/StyledButton';
 import './PhotoField.scss';
-
 
 const PhotoField = ({
     value,


### PR DESCRIPTION
Photos were slow. Now are slightly faster.

When taking photos before, an unnecessary state update after each photo being taken caused it to take an increasingly long amount of time for the photos to load.