### PR TITLE
Styled PhotoField

### DIFF
--- a/frontend/src/components/Fields/PhotoField.js
+++ b/frontend/src/components/Fields/PhotoField.js
@@ -152,21 +152,28 @@ const PhotoField = ({
                 <>
                     <br />
                     <div className="button-wrapper">
-                        <StyledButton onClick={confirmUpload} primary>
-                            {translations.components.button.discard.saveButton}
-                        </StyledButton>
-                        <StyledButton onClick={handleRetake} primary={false}>
-                            {
-                                translations.components.button.discard
-                                    .retakeButton
-                            }
-                        </StyledButton>
-                        <StyledButton onClick={resetUpload} primary={false}>
-                            {
-                                translations.components.button.discard
-                                    .cancelButton
-                            }
-                        </StyledButton>
+                        <div className="save-retake-button-wrapper">
+                            <StyledButton onClick={confirmUpload} primary>
+                                {
+                                    translations.components.button.discard
+                                        .saveButton
+                                }
+                            </StyledButton>
+                            <StyledButton onClick={handleRetake}>
+                                {
+                                    translations.components.button.discard
+                                        .retakeButton
+                                }
+                            </StyledButton>
+                        </div>
+                        <div>
+                            <StyledButton onClick={resetUpload} danger>
+                                {
+                                    translations.components.button.discard
+                                        .cancelButton
+                                }
+                            </StyledButton>
+                        </div>
                     </div>
                 </>
             );

--- a/frontend/src/components/Fields/PhotoField.scss
+++ b/frontend/src/components/Fields/PhotoField.scss
@@ -16,8 +16,12 @@
 
         .button-wrapper {
             display: flex;
-            justify-content: flex-end;
-            margin-left: 20px;
+            justify-content: space-between;
+            width: 100%;
+        }
+
+        .save-retake-button-wrapper {
+            display: inherit;
         }
     }
 }

--- a/frontend/src/components/StyledButton/StyledButton.js
+++ b/frontend/src/components/StyledButton/StyledButton.js
@@ -7,17 +7,27 @@ import PropTypes from 'prop-types';
 import { LANGUAGES } from '../../utils/constants';
 import { useTranslations } from '../../hooks/useTranslations';
 
-const StyledButton = ({ onClick, primary, children, isDisabled = false }) => {
+const StyledButton = ({
+    onClick,
+    primary,
+    danger,
+    children,
+    isDisabled = false,
+}) => {
     const selectedLang = useTranslations()[1];
     const saveBtnClassName =
         selectedLang === LANGUAGES.AR ? 'save-button-ar' : 'save-button';
 
+    let className = primary
+        ? 'button-wrapper-primary'
+        : 'button-wrapper-secondary';
+
+    if (danger) {
+        className = 'button-wrapper-danger';
+    }
+
     return (
-        <div
-            className={
-                primary ? 'button-wrapper-primary' : 'button-wrapper-secondary'
-            }
-        >
+        <div className={className}>
             <Button
                 className={saveBtnClassName}
                 onClick={onClick}
@@ -31,7 +41,8 @@ const StyledButton = ({ onClick, primary, children, isDisabled = false }) => {
 
 StyledButton.propTypes = {
     onClick: PropTypes.func.isRequired,
-    primary: PropTypes.bool.isRequired,
+    primary: PropTypes.bool,
+    danger: PropTypes.bool,
     children: PropTypes.node,
     isDisabled: PropTypes.bool,
 };

--- a/frontend/src/components/StyledButton/StyledButton.scss
+++ b/frontend/src/components/StyledButton/StyledButton.scss
@@ -60,3 +60,37 @@
         }
     }
 }
+
+.button-wrapper-danger {
+    .save-button {
+        background-color: $deleteRed;
+        color: white;
+        padding: 0 24px 0 24px;
+        height: 38px;
+        width: auto;
+        font-size: 12px;
+        font-weight: bold;
+        transition: all 0.2s;
+        border-radius: 2px;
+        &:hover {
+            background-color: $deleteRedHighlight;
+        }
+        box-shadow: 0px 2px 4px 1px rgba(0, 0, 0, 0.15);
+    }
+
+    .save-button-ar {
+        background-color: $deleteRed;
+        color: white;
+        padding: 0 24px 0 24px;
+        height: 38px;
+        width: auto;
+        font-size: 12px;
+        font-weight: bold;
+        transition: all 0.2s;
+        border-radius: 2px;
+        box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.15);
+        &:hover {
+            background-color: $deleteRedHighlight;
+        }
+    }
+}


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:

🚀 

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

Styled PhotoField. Wasn't much to do.

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #413 

## Todos

<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots

<img width="1433" alt="Screen Shot 2022-01-06 at 1 02 01 AM" src="https://user-images.githubusercontent.com/21179174/148342510-df2c33bd-1683-4de9-ab5c-8ae40022cff9.png">


<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
