### PR TITLE
Terminate TLS at Nginx

### DIFF
--- a/.ebextensions/ssl.config
+++ b/.ebextensions/ssl.config
@@ -1,0 +1,18 @@
+files:
+  "/etc/nginx/certs/server.crt":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      -----BEGIN CERTIFICATE-----
+      ${SERVER_CRT}
+      -----END CERTIFICATE-----
+
+  "/etc/nginx/certs/server.key":
+    mode: "000600"
+    owner: root
+    group: root
+    content: |
+      -----BEGIN PRIVATE KEY-----
+      ${SERVER_KEY}
+      -----END PRIVATE KEY-----

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,8 +35,11 @@ services:
 
   nginx:
     build: ./nginx
+    volumes:
+      - ./certs:/etc/nginx/certs:ro
     ports:
-      - 8080:80
+      - 80:80
+      - 443:443
     restart: always
     depends_on:
       - prosthetics_web_app

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -3,9 +3,22 @@ events {
 }
 
 http {
+    # Redirect all HTTP to HTTPS
     server {
         listen 80;
+        server_name www.hearing.3dp4me-software.org hearing.3dp4me-software.org
+                    www.prosthetics.3dp4me-software.org prosthetics.3dp4me-software.org
+                    www.pt.3dp4me-software.org pt.3dp4me-software.org;
+        return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen 443 ssl http2;
         server_name www.hearing.3dp4me-software.org hearing.3dp4me-software.org;
+
+        ssl_certificate /etc/nginx/certs/server.crt;
+        ssl_certificate_key /etc/nginx/certs/server.key;
+
         location / {
             client_max_body_size 100G;
             proxy_pass http://hearing_aid_web_app:5050/;


### PR DESCRIPTION
We're paying a lot of money to have AWS load balancers that terminate TLS even though we only ever have 1 instance running. 

If we terminate TLS at nginx we can remove a lot of the AWS infra and reduce costs.